### PR TITLE
Added *.provenance.update_date, bundle_uuid, and bundle_version columns

### DIFF
--- a/hca_bundle_tools/file_metadata_to_csv.py
+++ b/hca_bundle_tools/file_metadata_to_csv.py
@@ -22,6 +22,8 @@ class Flatten:
 
         self.default_order = order if order else [
              "path",
+             "^bundle_.*",
+             "^\\*\\.provenance\\.update_date",
              "^\\*\\.file_core\\.file_name",
              "^\\*\\.file_core\\.file_format",
              "^sequence_file.*",
@@ -135,7 +137,7 @@ class Flatten:
             return -1
         return best_a - best_b
 
-    def add_bundle_files_to_row(self, list_of_metadata_objects, dir_name=None):
+    def add_bundle_files_to_row(self, bundle_uuid, bundle_version, list_of_metadata_objects, dir_name=None):
         '''
 
         :param list_of_metadata_objects:
@@ -147,6 +149,10 @@ class Flatten:
         for file, content in file_uuids.items():
             obj = {}
 
+            obj['bundle_uuid'] = bundle_uuid
+            obj['bundle_version'] = bundle_version
+            obj["*.provenance.update_date"] = self._deep_get(content, ["provenance", "update_date"])
+            obj["*.provenance.document_id"] = self._deep_get(content, ["provenance", "document_id"])
             obj["*.file_core.file_name"] = self._deep_get(content, ["file_core", "file_name"])
             obj["*.file_core.file_format"] = self._deep_get(content, ["file_core", "file_format"])
 
@@ -244,7 +250,9 @@ def convert_bundle_dirs():
 
     for bundle in os.listdir(bundle_dir):
         # ignore any directory that isn't named with a uuid
-        if uuid4hex.match(bundle):
+        sep = bundle.index('.')
+        bundle_uuid, bundle_version = bundle[:sep], bundle[sep+1:]
+        if uuid4hex.match(bundle_uuid):
             print ("flattening " + bundle)
             metadata_files = []
             for file in glob.glob(bundle_dir + os.sep + bundle + os.sep + '*.json'):
@@ -252,7 +260,7 @@ def convert_bundle_dirs():
                     data = json.load(f)
                     metadata_files.append(data)
 
-            flattener.add_bundle_files_to_row(metadata_files, dir_name=bundle)
+            flattener.add_bundle_files_to_row(bundle_uuid, bundle_version, metadata_files, dir_name=bundle)
 
     if args.project:
         flattener.dump_by_project(delim=args.seperator)

--- a/hca_bundle_tools/file_metadata_to_csv.py
+++ b/hca_bundle_tools/file_metadata_to_csv.py
@@ -22,8 +22,6 @@ class Flatten:
 
         self.default_order = order if order else [
              "path",
-             "^bundle_.*",
-             "^\\*\\.provenance\\.update_date",
              "^\\*\\.file_core\\.file_name",
              "^\\*\\.file_core\\.file_format",
              "^sequence_file.*",
@@ -32,7 +30,11 @@ class Flatten:
              "^specimen_from_organism.*",
              "^cell_suspension.*",
              "^.*protocol.*",
-             "^project."
+             "^project.",
+             "^analysis_process.*",
+             "^process.*",
+             "^bundle_.*",
+             ".*provenance.update_date"
         ]
 
         self.default_ignore = ignore if ignore else [
@@ -151,8 +153,7 @@ class Flatten:
 
             obj['bundle_uuid'] = bundle_uuid
             obj['bundle_version'] = bundle_version
-            obj["*.provenance.update_date"] = self._deep_get(content, ["provenance", "update_date"])
-            obj["*.provenance.document_id"] = self._deep_get(content, ["provenance", "document_id"])
+            obj['*.provenance.update_date'] = self._deep_get(content, ["provenance", "update_date"])
             obj["*.file_core.file_name"] = self._deep_get(content, ["file_core", "file_name"])
             obj["*.file_core.file_format"] = self._deep_get(content, ["file_core", "file_format"])
 

--- a/hca_bundle_tools/file_metadata_to_csv.py
+++ b/hca_bundle_tools/file_metadata_to_csv.py
@@ -34,7 +34,7 @@ class Flatten:
              "^analysis_process.*",
              "^process.*",
              "^bundle_.*",
-             ".*provenance.update_date"
+             "^\\*\\.provenance\\.update_date"
         ]
 
         self.default_ignore = ignore if ignore else [


### PR DESCRIPTION
As per https://github.com/DataBiosphere/azul/issues/945, this PR contains changes to the script that adds the columns for bundle uuid, bundle version, and file version. They are named `bundle_uuid`, `bundle_version`, and `*.provenance.update_date`, respectively.